### PR TITLE
Ordered task set

### DIFF
--- a/src/main/java/com/github/myzhan/locust4j/AbstractTask.java
+++ b/src/main/java/com/github/myzhan/locust4j/AbstractTask.java
@@ -41,6 +41,15 @@ public abstract class AbstractTask implements Runnable {
      */
     public abstract void execute() throws Exception;
 
+    /**
+     * Check if task is valid.
+     *
+     * @return true if task is valid
+     */
+    public boolean isValid() {
+        return getWeight() >= 0;
+    }
+
     @Override
     public void run() {
         Runner runner = Locust.getInstance().getRunner();

--- a/src/main/java/com/github/myzhan/locust4j/Locust.java
+++ b/src/main/java/com/github/myzhan/locust4j/Locust.java
@@ -130,7 +130,7 @@ public class Locust {
     private List<AbstractTask> removeInvalidTasks(List<AbstractTask> tasks) {
         ListIterator<AbstractTask> iter = tasks.listIterator();
         while (iter.hasNext()) {
-            if (iter.next().getWeight() < 0) {
+            if (!iter.next().isValid()) {
                 iter.remove();
             }
         }

--- a/src/main/java/com/github/myzhan/locust4j/taskset/AbstractTaskSet.java
+++ b/src/main/java/com/github/myzhan/locust4j/taskset/AbstractTaskSet.java
@@ -21,6 +21,16 @@ public abstract class AbstractTaskSet extends AbstractTask {
     }
 
     /**
+     * Task set is valid if it contains tasks
+     *
+     * @return true if task set is valid
+     */
+    @Override
+    public boolean isValid() {
+        return super.isValid() && !tasks.isEmpty();
+    }
+
+    /**
      * Add a task to the task set.
      *
      * @param task test task that runs in a task set

--- a/src/main/java/com/github/myzhan/locust4j/taskset/OrderedTaskSet.java
+++ b/src/main/java/com/github/myzhan/locust4j/taskset/OrderedTaskSet.java
@@ -1,0 +1,60 @@
+package com.github.myzhan.locust4j.taskset;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.github.myzhan.locust4j.AbstractTask;
+
+/**
+ * @author nejckorasa
+ * @date 2019/01/28
+ */
+public class OrderedTaskSet extends AbstractTaskSet {
+
+    private int weight;
+    private String name;
+
+    private final Object lock = new Object();
+    private AtomicInteger position = new AtomicInteger(0);
+
+    public OrderedTaskSet(String name, int weight) {
+        super();
+        this.name = name;
+        this.weight = weight;
+    }
+
+    @Override
+    public void addTask(AbstractTask task) {
+        tasks.add(task);
+    }
+
+    public AbstractTask getTask(int index) {
+        return tasks.get(index % tasks.size());
+    }
+
+    @Override
+    public int getWeight() {
+        return weight;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void execute() throws Exception {
+        final int nextIndex = getNextIndex();
+        AbstractTask task = getTask(nextIndex);
+        task.execute();
+    }
+
+    public int getNextIndex() {
+        final int size = tasks.size();
+        int index;
+        synchronized (lock) {
+            index = position.get() % size;
+            position.set(index + 1);
+        }
+        return index;
+    }
+}

--- a/src/main/java/com/github/myzhan/locust4j/taskset/OrderedTaskSet.java
+++ b/src/main/java/com/github/myzhan/locust4j/taskset/OrderedTaskSet.java
@@ -6,7 +6,8 @@ import com.github.myzhan.locust4j.AbstractTask;
 
 /**
  * @author nejckorasa
- * @date 2019/01/28
+ *
+ * OrderedTaskSet ignores weights of individual tasks
  */
 public class OrderedTaskSet extends AbstractTaskSet {
 
@@ -27,10 +28,6 @@ public class OrderedTaskSet extends AbstractTaskSet {
         tasks.add(task);
     }
 
-    public AbstractTask getTask(int index) {
-        return tasks.get(index % tasks.size());
-    }
-
     @Override
     public int getWeight() {
         return weight;
@@ -43,13 +40,20 @@ public class OrderedTaskSet extends AbstractTaskSet {
 
     @Override
     public void execute() throws Exception {
-        final int nextIndex = getNextIndex();
-        AbstractTask task = getTask(nextIndex);
+        AbstractTask task = getTask();
         task.execute();
     }
 
-    public int getNextIndex() {
+    public AbstractTask getTask() {
+        return tasks.isEmpty() ? null : tasks.get(getNextIndex());
+    }
+
+    public Integer getNextIndex() {
         final int size = tasks.size();
+        if (size == 0) {
+            return 0;
+        }
+
         int index;
         synchronized (lock) {
             index = position.get() % size;

--- a/src/test/java/com/github/myzhan/locust4j/taskset/OrderedTaskSetTest.java
+++ b/src/test/java/com/github/myzhan/locust4j/taskset/OrderedTaskSetTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 
 /**
  * @author nejckorasa
- * @date 2019/01/28
  */
 public class OrderedTaskSetTest
 {
@@ -40,8 +39,7 @@ public class OrderedTaskSetTest
     }
 
     @Test
-    public void testOrderedTasksDistribution() throws Exception
-    {
+    public void testOrderedTasksDistribution() throws Exception {
         OrderedTaskSet taskSet = new OrderedTaskSet("orderedTaskSet", 1);
 
         // taskSet size = 5
@@ -60,8 +58,8 @@ public class OrderedTaskSetTest
         taskSet.execute();
         taskSet.execute();
 
-        Assert.assertEquals(2, taskSet.getNextIndex());
-        Assert.assertEquals(3, taskSet.getNextIndex());
-        Assert.assertEquals(4, taskSet.getNextIndex());
+        Assert.assertEquals(2, taskSet.getNextIndex().intValue());
+        Assert.assertEquals(3, taskSet.getNextIndex().intValue());
+        Assert.assertEquals(4, taskSet.getNextIndex().intValue());
     }
 }

--- a/src/test/java/com/github/myzhan/locust4j/taskset/OrderedTaskSetTest.java
+++ b/src/test/java/com/github/myzhan/locust4j/taskset/OrderedTaskSetTest.java
@@ -1,0 +1,67 @@
+package com.github.myzhan.locust4j.taskset;
+
+import com.github.myzhan.locust4j.AbstractTask;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author nejckorasa
+ * @date 2019/01/28
+ */
+public class OrderedTaskSetTest
+{
+    private static class TestTask extends AbstractTask {
+        public int weight;
+        public String name;
+
+        private TestTask(String name, int weight) {
+            this.name = name;
+            this.weight = weight;
+        }
+
+        @Override
+        public int getWeight() {
+            return weight;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public void execute() {
+            try {
+                System.out.println("I'm " + name);
+            } catch (RuntimeException ex) {
+                ex.printStackTrace();
+            }
+        }
+    }
+
+    @Test
+    public void testOrderedTasksDistribution() throws Exception
+    {
+        OrderedTaskSet taskSet = new OrderedTaskSet("orderedTaskSet", 1);
+
+        // taskSet size = 5
+        taskSet.addTask(new TestTask("test1", 10));
+        taskSet.addTask(new TestTask("test2", 20));
+        taskSet.addTask(new TestTask("test3", 20));
+        taskSet.addTask(new TestTask("test4", 20));
+        taskSet.addTask(new TestTask("test5", 20));
+
+        // execute 7 times
+        taskSet.execute();
+        taskSet.execute();
+        taskSet.execute();
+        taskSet.execute();
+        taskSet.execute();
+        taskSet.execute();
+        taskSet.execute();
+
+        Assert.assertEquals(2, taskSet.getNextIndex());
+        Assert.assertEquals(3, taskSet.getNextIndex());
+        Assert.assertEquals(4, taskSet.getNextIndex());
+    }
+}

--- a/src/test/java/com/github/myzhan/locust4j/taskset/OrderedTaskSetTest.java
+++ b/src/test/java/com/github/myzhan/locust4j/taskset/OrderedTaskSetTest.java
@@ -62,4 +62,31 @@ public class OrderedTaskSetTest
         Assert.assertEquals(3, taskSet.getNextIndex().intValue());
         Assert.assertEquals(4, taskSet.getNextIndex().intValue());
     }
+
+    @Test
+    public void testOrderedTasksWeighingDistribution() {
+        OrderedTaskSet taskSet = new OrderedTaskSet("orderedTaskSet", 1);
+
+        // taskSet size = 5
+        // weight sum = 10
+        taskSet.addTask(new TestTask("test1", 2));
+        taskSet.addTask(new TestTask("test2", 2));
+        taskSet.addTask(new TestTask("test3", 4));
+        taskSet.addTask(new TestTask("test4", 1));
+        taskSet.addTask(new TestTask("test5", 1));
+
+        taskSet.distributeWeights();
+
+        Assert.assertEquals("test1", taskSet.getTask().getName());
+        Assert.assertEquals("test1", taskSet.getTask().getName());
+        Assert.assertEquals("test2", taskSet.getTask().getName());
+        Assert.assertEquals("test2", taskSet.getTask().getName());
+        Assert.assertEquals("test3", taskSet.getTask().getName());
+        Assert.assertEquals("test3", taskSet.getTask().getName());
+        Assert.assertEquals("test3", taskSet.getTask().getName());
+        Assert.assertEquals("test3", taskSet.getTask().getName());
+        Assert.assertEquals("test4", taskSet.getTask().getName());
+        Assert.assertEquals("test5", taskSet.getTask().getName());
+        Assert.assertEquals("test1", taskSet.getTask().getName());
+    }
 }

--- a/src/test/java/com/github/myzhan/locust4j/taskset/WeighingTaskSetTest.java
+++ b/src/test/java/com/github/myzhan/locust4j/taskset/WeighingTaskSetTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
  * @author myzhan
  * @date 2018/12/06
  */
-public class TestWeighingTaskSet {
+public class WeighingTaskSetTest {
 
     private class TestTask extends AbstractTask {
         public int weight;


### PR DESCRIPTION
Adds ordered task set. 

The idea is that task are executed in order. 

The downside is that by default weights of individual tasks inside the set are completely ignored. For that reason `distributeWeights()` is added that creates ordered weighing distribution of tasks. Weights of individual tasks then represent the exact number of executions for that task in each loop.