### PR TITLE
Add cpu usage stats to heartbeat messages

### DIFF
--- a/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
+++ b/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
@@ -1,6 +1,8 @@
 package com.github.myzhan.locust4j.runtime;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +19,7 @@ import com.github.myzhan.locust4j.message.Message;
 import com.github.myzhan.locust4j.rpc.Client;
 import com.github.myzhan.locust4j.stats.Stats;
 import com.github.myzhan.locust4j.utils.Utils;
+import com.sun.management.OperatingSystemMXBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -361,8 +364,9 @@ public class Runner {
             while (true) {
                 try {
                     Thread.sleep(HEARTBEAT_INTERVAL);
-                    Map<String, Object> data = new HashMap<>(1);
+                    Map<String, Object> data = new HashMap<>(2);
                     data.put("state", runner.state.name().toLowerCase());
+                    data.put("current_cpu_usage", getCpuUsage());
                     runner.rpcClient.send(new Message("heartbeat", data, runner.nodeID));
                 } catch (InterruptedException ex) {
                     return;
@@ -370,6 +374,12 @@ public class Runner {
                     logger.error("Error in running the heartbeat", ex);
                 }
             }
+        }
+
+        private int getCpuUsage() {
+            OperatingSystemMXBean operatingSystemMXBean =
+                    (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
+            return (int) (operatingSystemMXBean.getSystemCpuLoad() * 100);
         }
     }
 

--- a/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
+++ b/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
@@ -353,6 +353,8 @@ public class Runner {
         private static final int HEARTBEAT_INTERVAL = 1000;
         private Runner runner;
 
+        private OperatingSystemMXBean osBean = getOsBean();
+
         private Heartbeat(Runner runner) {
             this.runner = runner;
         }
@@ -377,9 +379,11 @@ public class Runner {
         }
 
         private int getCpuUsage() {
-            OperatingSystemMXBean operatingSystemMXBean =
-                    (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
-            return (int) (operatingSystemMXBean.getSystemCpuLoad() * 100);
+            return (int) osBean.getSystemCpuLoad() * 100;
+        }
+
+        private OperatingSystemMXBean getOsBean() {
+            return (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
         }
     }
 

--- a/src/test/java/com/github/myzhan/locust4j/runtime/TestRunner.java
+++ b/src/test/java/com/github/myzhan/locust4j/runtime/TestRunner.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 /**
@@ -188,5 +189,23 @@ public class TestRunner {
         assertEquals("quit", quit.getType());
         assertNull(quit.getData());
         assertEquals(runner.nodeID, quit.getNodeID());
+    }
+
+    @Test
+    public void TestSendHeartbeat() throws Exception {
+        MockRPCClient client = new MockRPCClient();
+
+        runner.setRPCClient(client);
+        runner.getReady();
+
+        Message clientReady = client.getToServerQueue().take();
+        assertEquals("client_ready", clientReady.getType());
+
+        Message heartbeat = client.getToServerQueue().take();
+        assertEquals("heartbeat", heartbeat.getType());
+        assertNotNull(heartbeat.getData().get("current_cpu_usage"));
+        assertNotNull(heartbeat.getData().get("state"));
+
+        runner.quit();
     }
 }


### PR DESCRIPTION
Locust [since 0.14.0](https://github.com/locustio/locust/commit/02a995bbd21a27aa033af2c2dd97081ccbaa7424#diff-3b46e73ebc77b7981249d967363726e1R446) requires CPU usage to be reported by clients. Somehow this also prevented the master from properly recording heartbeats (although I'm not sure how, as that happens earlier in the control flow).

CPU usage extraction: https://github.com/locustio/locust/blob/93eec54bd53576304c925ceb8c1e8de5981d7b24/locust/runners.py#L462

Heartbeat reset: https://github.com/locustio/locust/blob/93eec54bd53576304c925ceb8c1e8de5981d7b24/locust/runners.py#L460

No matter, this should be included and also appears to fix the heartbeat issue.