### PR TITLE
Adding onStart and onStop method in tasks

### DIFF
--- a/src/main/java/com/github/myzhan/locust4j/AbstractTask.java
+++ b/src/main/java/com/github/myzhan/locust4j/AbstractTask.java
@@ -45,41 +45,70 @@ public abstract class AbstractTask implements Runnable {
      */
     public abstract void execute() throws Exception;
 
+    /**
+     * This method will be executed once before the test loop. By default, nothing will be executed.
+     *
+     * @throws Exception if an execption is thronw then a failure will be recorded and test
+     *                   scenarios will not be executed
+     */
+    public void onStart() throws Exception {
+
+    }
+
+    /**
+     * This method will be executed once after the test loop stopped, whether it ends in failure or not.
+     * By default, nothing will be executed
+     */
+    public void onStop() {
+
+    }
+
     @Override
     public void run() {
         Runner runner = Locust.getInstance().getRunner();
 
-        while (true) {
-            if (RunnerState.Stopped.equals(runner.getState()) || RunnerState.Ready.equals(runner.getState())) {
-                // The runner's state is not spawning or running, so break the loop.
-                return;
-            }
+        try {
+            onStart();
+        } catch (Exception ex) {
+            logger.error("Exception when executing onStart", ex);
+            Locust.getInstance().recordFailure("onStart", "error", 0, ex.getMessage());
+            return;
+        }
+        try {
+            while (true) {
+                if (runner.getState() == RunnerState.Stopped || runner.getState() == RunnerState.Ready) {
+                    // The runner's state is not spawning or running, so break the loop.
+                    return;
+                }
 
-            if (Thread.currentThread().isInterrupted()) {
-                return;
-            }
+                if (Thread.currentThread().isInterrupted()) {
+                    return;
+                }
 
-            try {
-                if (Locust.getInstance().isRateLimitEnabled()) {
-                    // block and wait for next permit
-                    boolean blocked = Locust.getInstance().getRateLimiter().acquire();
-                    if (!blocked) {
+                try {
+                    if (Locust.getInstance().isRateLimitEnabled()) {
+                        // block and wait for next permit
+                        boolean blocked = Locust.getInstance().getRateLimiter().acquire();
+                        if (!blocked) {
+                            this.execute();
+                        }
+                    } else {
                         this.execute();
                     }
-                } else {
-                    this.execute();
+                } catch (InterruptedException ex) {
+                    return;
+                } catch (Exception ex) {
+                    logger.error("Unknown exception when executing the task", ex);
+                    Locust.getInstance().recordFailure("unknown", "error", 0, ex.getMessage());
+                } catch (Error err) {
+                    // Error happens, print out the stacktrace then rethrow it to the thread pool.
+                    // This task will be discarded by the thread pool.
+                    logger.error("Unknown exception when executing the task", err);
+                    throw err;
                 }
-            } catch (InterruptedException ex) {
-                return;
-            } catch (Exception ex) {
-                logger.error("Unknown exception when executing the task", ex);
-                Locust.getInstance().recordFailure("unknown", "error", 0, ex.getMessage());
-            } catch (Error err) {
-                // Error happens, print out the stacktrace then rethrow it to the thread pool.
-                // This task will be discarded by the thread pool.
-                logger.error("Unknown exception when executing the task", err);
-                throw err;
             }
+        } finally {
+            onStop();
         }
     }
 }

--- a/src/main/java/com/github/myzhan/locust4j/Locust.java
+++ b/src/main/java/com/github/myzhan/locust4j/Locust.java
@@ -95,8 +95,8 @@ public class Locust {
      * @param rateLimiter builtin or custom rate limiter
      * @since 1.0.3
      */
-    public void setRateLimiter(AbstractRateLimiter rateLimiter) {
-        this.rateLimitEnabled = true;
+    public void setRateLimiter(AbstractRateLimiter rateLimiter) {        
+        this.rateLimitEnabled = rateLimiter != null;
         this.rateLimiter = rateLimiter;
     }
 
@@ -128,6 +128,10 @@ public class Locust {
      */
     public void setVerbose(boolean v) {
         this.verbose = v;
+    }
+
+    protected void setRunner(Runner runner) {
+        this.runner = runner;
     }
 
     protected Runner getRunner() {
@@ -201,11 +205,20 @@ public class Locust {
     public void dryRun(List<AbstractTask> tasks) {
         logger.debug("Running tasks without connecting to master.");
         for (AbstractTask task : tasks) {
+            logger.debug("Running task named {} onStart", task.getName());
+            try {
+                task.onStart();
+            } catch (Exception ex) {
+                logger.error("Unknown exception when calling onStart", ex);
+            }
+
             logger.debug("Running task named {}", task.getName());
             try {
                 task.execute();
             } catch (Exception ex) {
                 logger.error("Unknown exception when executing the task", ex);
+            } finally {
+                task.onStop();
             }
         }
     }


### PR DESCRIPTION
onStart and onStop allows tasks to have intialization and clean up code. Notice that there are a number of tests that needs to be updated in order to prevent interference