### PR TITLE
Send -1 as version when sending client_ready message after test has stopped

### DIFF
--- a/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
+++ b/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
@@ -288,7 +288,7 @@ public class Runner {
                 logger.debug("Recv stop message from master, all the workers are stopped");
                 try {
                     this.rpcClient.send(new Message("client_stopped", null, null, this.nodeID));
-                    this.rpcClient.send(new Message("client_ready", null, null, this.nodeID));
+                    this.rpcClient.send(new Message("client_ready", null, "-1", this.nodeID));
                     this.state = RunnerState.Ready;
                 } catch (IOException ex) {
                     logger.error("Error while switching from the state stopped to ready", ex);


### PR DESCRIPTION
This fixes a bug where after stopping the test the workers disappear. 

**Locust version**: 2.0.0b3
**Locust4j version**: master

**Steps to reproduce** 
- Stop a running test
- Expected: workers to remain 'ready'. Actual: ready workers drop to 0. Logs contain:
  > worker_1   | 21:34:30.713 [Thread-2receive-from-client] DEBUG com.github.myzhan.locust4j.runtime.Runner - Recv stop message from master, all the workers are stopped
master_1   | [2021-08-14 21:34:30,715] 1e6ea2aa04b2/INFO/locust.runners: Removing 0fff9756d6ca_3bcbb4e6b4a4fb9bd4e00c49e9e2da23 client from running clients
master_1   | [2021-08-14 21:34:30,715] 1e6ea2aa04b2/ERROR/locust.runners: An old (pre 2.0) worker tried to connect (b0aa3c23ab9b_c2f230bf39580a6048734e537229e70b). That's not going to work.
master_1   | [2021-08-14 21:34:30,715] 1e6ea2aa04b2/ERROR/locust.runners: An old (pre 2.0) worker tried to connect (0fff9756d6ca_3bcbb4e6b4a4fb9bd4e00c49e9e2da23). That's not going to work.


The "-1" version is included in the `client_ready` message sent when the worker first starts, but was missing when this message was sent after a test has been stopped.