### PR TITLE
Include user_classes_count on stats message

### DIFF
--- a/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
+++ b/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
@@ -373,6 +373,7 @@ public class Runner {
                         continue;
                     }
                     data.put("user_count", runner.numClients);
+                    data.put("user_classes_count", runner.userClassesCountFromMaster);
                     runner.rpcClient.send(new Message("stats", data, null, runner.nodeID));
                 } catch (InterruptedException ex) {
                     return;

--- a/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
+++ b/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
@@ -59,7 +59,7 @@ public class Runner {
     /**
      * We save user_class_count in spawn message and send it back to master without modification.
      */
-    private Map<String, Integer> userClassesCountFromMaster;
+    protected Map<String, Integer> userClassesCountFromMaster;
 
     /**
      * Remote params sent from the master, which is set before spawning begins.


### PR DESCRIPTION
This fixes a bug where errors are appearing in master. Although there doesn't appear to be any noticeable impact to Locust.

**Locust version**: 2.0.0b3
**Locust4j version**: master

The following error appears when running atest:

> master_1   | [2021-08-14 21:42:06,719] 1e6ea2aa04b2/ERROR/root: Uncaught exception in event handler: 
master_1   | Traceback (most recent call last):
master_1   |   File "/usr/local/lib/python3.8/site-packages/locust/event.py", line 40, in fire
master_1   |     handler(**kwargs)
master_1   |   File "/usr/local/lib/python3.8/site-packages/locust/runners.py", line 621, in on_worker_report
master_1   |     self.clients[client_id].user_classes_count = data["user_classes_count"]
master_1   | KeyError: 'user_classes_count'

Locust master expects `user_classes_count` to be included in stats message. This PR adds that.