### PR TITLE
Fix task threads closed on step up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,18 @@
             <version>1.21</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.11.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.11.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
+++ b/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
@@ -137,6 +137,10 @@ public class Runner {
         this.tasks = tasks;
     }
 
+    protected void setTaskExecutor(ThreadPoolExecutor taskExecutor) {
+        this.taskExecutor = taskExecutor;
+    }
+
     private void spawnWorkers(int spawnCount) {
         logger.debug("Required {} clients. Currently running {}.", spawnCount, this.taskExecutor.getActiveCount());
 
@@ -193,9 +197,8 @@ public class Runner {
 
     protected void startSpawning(int spawnCount) {
         Stats.getInstance().wakeMeUp();
-
         if(this.taskExecutor == null) {
-            this.taskExecutor = new ThreadPoolExecutor(spawnCount, spawnCount, 0L, TimeUnit.MILLISECONDS,
+            this.setTaskExecutor(new ThreadPoolExecutor(spawnCount, spawnCount, 0L, TimeUnit.MILLISECONDS,
                     new LinkedBlockingQueue<Runnable>(),
                     new ThreadFactory() {
                         @Override
@@ -204,7 +207,7 @@ public class Runner {
                             thread.setName("locust4j-worker#" + threadNumber.getAndIncrement());
                             return thread;
                         }
-                    });
+                    }));
         } else if (spawnCount > this.taskExecutor.getMaximumPoolSize()){
             this.taskExecutor.setMaximumPoolSize(spawnCount);
             this.taskExecutor.setCorePoolSize(spawnCount);

--- a/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
+++ b/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
@@ -184,7 +184,7 @@ public class Runner {
                 if (future != null) {
                     future.cancel(true);
                 }
-                logger.debug("Removing thread to task, which name is {}", task.getName());
+                logger.debug("Removing thread from task, which name is {}", task.getName());
             }
 
             futures.put(task.getName(), runningTasks);

--- a/src/test/java/com/github/myzhan/locust4j/LocustTestHelper.java
+++ b/src/test/java/com/github/myzhan/locust4j/LocustTestHelper.java
@@ -1,0 +1,10 @@
+package com.github.myzhan.locust4j;
+
+import com.github.myzhan.locust4j.runtime.Runner;
+
+public class LocustTestHelper  {
+
+    public static void setLocustRunner(Runner runner) {
+        Locust.getInstance().setRunner(runner);
+    }
+}

--- a/src/test/java/com/github/myzhan/locust4j/runtime/TestRunner.java
+++ b/src/test/java/com/github/myzhan/locust4j/runtime/TestRunner.java
@@ -3,13 +3,21 @@ package com.github.myzhan.locust4j.runtime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import com.github.myzhan.locust4j.AbstractTask;
+import com.github.myzhan.locust4j.LocustTestHelper;
 import com.github.myzhan.locust4j.message.Message;
 import com.github.myzhan.locust4j.stats.Stats;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,11 +34,16 @@ public class TestRunner {
 
     private Runner runner;
 
+    private MockRPCClient client;
+
     @Before
     public void before() {
         runner = new Runner();
         runner.setStats(new Stats());
         runner.setTasks(Collections.singletonList((AbstractTask) new TestTask()));
+        client = new MockRPCClient();
+        runner.setRPCClient(client);
+        LocustTestHelper.setLocustRunner(runner);
     }
 
     private static class TestTask extends AbstractTask {
@@ -70,9 +83,6 @@ public class TestRunner {
 
     @Test
     public void TestOnInvalidSpawnMessage() {
-        MockRPCClient client = new MockRPCClient();
-
-        runner.setRPCClient(client);
 
         runner.getReady();
 
@@ -95,9 +105,7 @@ public class TestRunner {
 
     @Test
     public void TestOnMessage() throws Exception {
-        MockRPCClient client = new MockRPCClient();
 
-        runner.setRPCClient(client);
         runner.setHeartbeatStopped(true);
 
         runner.getReady();
@@ -159,9 +167,7 @@ public class TestRunner {
 
     @Test
     public void TestGetReadyAndQuit() throws Exception {
-        MockRPCClient client = new MockRPCClient();
 
-        runner.setRPCClient(client);
         runner.getReady();
 
         Message clientReady = client.getToServerQueue().take();
@@ -179,9 +185,7 @@ public class TestRunner {
 
     @Test
     public void TestSendHeartbeat() throws Exception {
-        MockRPCClient client = new MockRPCClient();
 
-        runner.setRPCClient(client);
         runner.getReady();
 
         Message clientReady = client.getToServerQueue().take();
@@ -193,5 +197,103 @@ public class TestRunner {
         assertNotNull(heartbeat.getData().get("state"));
 
         runner.quit();
+    }
+
+
+    @Test
+    public void TestSpawningWorkersScaleOut() throws Exception {
+        runner.setHeartbeatStopped(true);
+        runner.getReady();
+
+        ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<Runnable>(),
+                new ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread thread = new Thread(r);
+                        return thread;
+                    }
+                });
+        ThreadPoolExecutor spyThreadPoolExecutor = Mockito.spy(threadPoolExecutor);
+        runner.setTaskExecutor(spyThreadPoolExecutor);
+
+        this.sendSpawnMessage(2);
+
+        // Verify pool size is set correctly. Order is important.
+        InOrder orderVerifier = Mockito.inOrder(spyThreadPoolExecutor);
+        orderVerifier.verify(spyThreadPoolExecutor).setMaximumPoolSize(2);
+        orderVerifier.verify(spyThreadPoolExecutor).setCorePoolSize(2);
+
+        assertEquals(2, runner.numClients);
+
+        // Scale in worker
+        this.sendSpawnMessage(3);
+
+        // Verify pool size is set correctly. Order is important.
+        orderVerifier.verify(spyThreadPoolExecutor).setMaximumPoolSize(3);
+        orderVerifier.verify(spyThreadPoolExecutor).setCorePoolSize(3);
+
+        // Verify that only 3 tasks were submitted in total
+        verify(spyThreadPoolExecutor, times(3)).submit(isA(AbstractTask.class));
+
+        assertEquals(3, runner.numClients);
+
+        runner.quit();
+    }
+
+    @Test
+    public void TestSpawningWorkersScaleIn() throws Exception {
+        runner.setHeartbeatStopped(true);
+        runner.getReady();
+
+        ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<Runnable>(),
+                new ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread thread = new Thread(r);
+                        return thread;
+                    }
+                });
+        ThreadPoolExecutor spyThreadPoolExecutor = Mockito.spy(threadPoolExecutor);
+        runner.setTaskExecutor(spyThreadPoolExecutor);
+
+        this.sendSpawnMessage(3);
+
+        // Verify pool size is set correctly. Order is important.
+        InOrder orderVerifier = Mockito.inOrder(spyThreadPoolExecutor);
+        orderVerifier.verify(spyThreadPoolExecutor).setMaximumPoolSize(3);
+        orderVerifier.verify(spyThreadPoolExecutor).setCorePoolSize(3);
+
+        assertEquals(3, runner.numClients);
+
+        // Scale in worker
+        this.sendSpawnMessage(2);
+
+        // Verify pool size is set correctly. Order is important.
+        orderVerifier.verify(spyThreadPoolExecutor).setCorePoolSize(2);
+        orderVerifier.verify(spyThreadPoolExecutor).setMaximumPoolSize(2);
+
+        // Verify that only 3 tasks were submitted in total
+        verify(spyThreadPoolExecutor, times(3)).submit(isA(AbstractTask.class));
+
+        assertEquals(2, runner.numClients);
+
+        runner.quit();
+    }
+
+    private void sendSpawnMessage(int usercount) throws Exception {
+        Map<String, Object> spawnData = new HashMap<>();
+        Map<String, Integer> userClassesCount = new HashMap<String, Integer>(1);
+        userClassesCount.put("dummy", usercount);
+        spawnData.put("user_classes_count", userClassesCount);
+        spawnData.put("host", "www.github.com");
+
+        // send spawn message
+        client.getFromServerQueue().offer(new Message(
+                "spawn", spawnData, null, null));
+
+        // wait for spawn complete
+        Thread.sleep(100);
     }
 }


### PR DESCRIPTION
When running a custom load test shape, there would a be drop in the RPS whenever there was a change in the number of users.

**Locust version**: 2.0.0b3
**Locust4j version**: master

**Steps to reproduce** 
- Run a test with a custom load shape. E.g.
```python
class StepLoadShape(LoadTestShape):
    step_time = 30
    step_load = 10
    spawn_rate = 2

    def tick(self):
        run_time = self.get_run_time()
        current_step = math.floor(run_time / self.step_time) + 1

        if current_step > 7:
            return None

        if current_step > 3:
            current_step = 8 - current_step

        return (current_step * self.step_load, self.spawn_rate)
```
- Expected: 
![rps_no-data-reset](https://user-images.githubusercontent.com/54176138/129461442-283dfa04-5ae5-4faf-9d54-86791d922c04.png)
- Actual:
![rps_data-reset](https://user-images.githubusercontent.com/54176138/129461447-4f8fbd2c-34ff-4dca-819e-a7d4f358c114.png)

I noticed that all threads were being terminated and recreated on each spawn message, and that the stast were being reset. This PR:

- Stores a reference to the futures returned by `ThreadPoolExecutor.submit()`
- On spawn messages, instead of stopping the treads, adds or removes individual threads by first adjusting the pool size and then cancelling/creating tasks.
- Removes the call to reset stats.

The expected image above was taken with this patch applied.