### PR TITLE
Fix requests counts on error events.

### DIFF
--- a/src/main/java/com/github/myzhan/locust4j/stats/Stats.java
+++ b/src/main/java/com/github/myzhan/locust4j/stats/Stats.java
@@ -137,6 +137,7 @@ public class Stats implements Runnable {
 
             RequestFailure failureMessage = reportFailureQueue.poll();
             if (null != failureMessage) {
+                this.logRequest(failureMessage.getRequestType(), failureMessage.getName(), failureMessage.getResponseTime(), 0);
                 this.logError(failureMessage.getRequestType(), failureMessage.getName(), failureMessage.getError());
                 allEmpty = false;
             }

--- a/src/test/java/com/github/myzhan/locust4j/stats/TestStats.java
+++ b/src/test/java/com/github/myzhan/locust4j/stats/TestStats.java
@@ -117,6 +117,7 @@ public class TestStats {
 
     @Test
     public void TestLogError() {
+        stats.logRequest("http", "test", 1000L, 0);
         stats.logError("http", "test", "Test Error");
         stats.logError("udp", "test", "Unknown Error");
 
@@ -125,6 +126,7 @@ public class TestStats {
 
         StatsEntry total = stats.getTotal();
         assertEquals(2, total.getNumFailures());
+        assertEquals(1, total.getNumRequests());
 
         Map<String, Map<String, Object>> errors = stats.serializeErrors();
 


### PR DESCRIPTION
When errors happen requests are not being counted which throws off
success failure ratios, along with rps.