### PR TITLE
Draft: ZeroMQ socket synchronization, spawning_complete and several cosmetic fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.myzhan</groupId>
     <artifactId>locust4j</artifactId>
-    <version>2.2.5</version>
+    <version>2.2.6</version>
     <name>locust4j</name>
     <description>Locust4j is a load generator for locust, written in Java.</description>
     <url>https://github.com/myzhan/locust4j</url>

--- a/src/main/java/com/github/myzhan/locust4j/rpc/ZeromqClient.java
+++ b/src/main/java/com/github/myzhan/locust4j/rpc/ZeromqClient.java
@@ -1,10 +1,12 @@
 package com.github.myzhan.locust4j.rpc;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 
 import com.github.myzhan.locust4j.message.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQException;
 
@@ -23,40 +25,53 @@ public class ZeromqClient implements Client {
     private final ZMQ.Context context = ZMQ.context(1);
     private final String identity;
     private final ZMQ.Socket dealerSocket;
+    private final Object dealerSocketSync = new Object();
 
     public ZeromqClient(String host, int port, String nodeID) {
         this.identity = nodeID;
-        this.dealerSocket = context.socket(ZMQ.DEALER);
+        this.dealerSocket = context.socket(SocketType.DEALER);
         this.dealerSocket.setIdentity(this.identity.getBytes());
+        this.dealerSocket.setImmediate(true);
+        this.dealerSocket.setReceiveTimeOut(300);
         boolean connected = this.dealerSocket.connect(String.format("tcp://%s:%d", host, port));
         if (connected) {
             logger.debug("Locust4j is connected to master({}:{})", host, port);
         } else {
             logger.debug("Locust4j isn't connected to master({}:{}), please check your network situation", host, port);
         }
-
     }
 
     @Override
     public Message recv() throws IOException {
-        try {
-            byte[] bytes = this.dealerSocket.recv();
-            return new Message(bytes);
-        } catch (ZMQException ex) {
-            throw new IOException("Failed to receive ZeroMQ message", ex);
+        while (true) {
+            try {
+                byte[] bytes = this.dealerSocket.recv();
+                if (bytes != null) return new Message(bytes);
+            } catch (ZMQException ex) {
+                throw new IOException("Failed to receive ZeroMQ message", ex);
+            }
+            if (Thread.currentThread().isInterrupted())
+                throw new InterruptedIOException();
         }
     }
 
     @Override
     public void send(Message message) throws IOException {
-        byte[] bytes = message.getBytes();
-        this.dealerSocket.send(bytes);
+        try {
+            byte[] bytes = message.getBytes();
+            synchronized(dealerSocketSync) {
+                dealerSocket.send(bytes);
+            }
+        } catch(Exception ex) {
+            throw new IOException("Failed to send message to master", ex);
+        }
     }
 
     @Override
     public void close() {
-        dealerSocket.close();
+        synchronized(dealerSocketSync) {
+            dealerSocket.close();
+        }
         context.close();
     }
 }
-

--- a/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
+++ b/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
@@ -330,7 +330,7 @@ public class Runner {
 
                 this.state = RunnerState.Running;
 
-            } else if ("spawning_complete".equals(type) && spawnMessageIsValid(message)) {
+            } else if ("spawning_complete".equals(type)) {
                 AbstractRateLimiter rateLimiter = Locust.getInstance().getRateLimiter();
                 if (rateLimiter != null && rateLimiter.isStopped()) {
                     rateLimiter.start();
@@ -354,7 +354,7 @@ public class Runner {
                 this.onSpawnMessage(message);
                 this.state = RunnerState.Running;
 
-            } else if ("spawning_complete".equals(type) && spawnMessageIsValid(message)) {
+            } else if ("spawning_complete".equals(type)) {
                 this.state = RunnerState.Running;
 
             } else if ("stop".equals(type)) {
@@ -386,7 +386,7 @@ public class Runner {
                     rateLimiter.start();
                 }
 
-            } else if ("spawning_complete".equals(type) && spawnMessageIsValid(message)) {
+            } else if ("spawning_complete".equals(type)) {
                 AbstractRateLimiter rateLimiter = Locust.getInstance().getRateLimiter();
                 if (rateLimiter != null && rateLimiter.isStopped()) {
                     rateLimiter.start();

--- a/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
+++ b/src/main/java/com/github/myzhan/locust4j/runtime/Runner.java
@@ -227,7 +227,7 @@ public class Runner {
 
     protected void spawnComplete() {
         Map<String, Object> data = new HashMap<>(1);
-        data.put("count", this.numClients);
+        data.put("user_count", this.numClients);
         data.put("user_classes_count", this.userClassesCountFromMaster);
         try {
             this.rpcClient.send((new Message("spawning_complete", data, -1, this.nodeID)));
@@ -328,16 +328,16 @@ public class Runner {
                     rateLimiter.start();
                 }
 
-            } else if ("spawning_complete".equals(type) && spawnMessageIsValid(message)) {
-                this.state = RunnerState.Spawning;
-                this.onSpawnMessage(message);
+                this.state = RunnerState.Running;
 
+            } else if ("spawning_complete".equals(type) && spawnMessageIsValid(message)) {
                 AbstractRateLimiter rateLimiter = Locust.getInstance().getRateLimiter();
                 if (rateLimiter != null && rateLimiter.isStopped()) {
                     rateLimiter.start();
                 }
 
                 this.state = RunnerState.Running;
+
             } else if ("ack".equals(type)) {
                 this.waitForAck.countDown();
                 this.masterConnected = true;
@@ -347,14 +347,16 @@ public class Runner {
                     this.workerIndex = (int) data.get("index");
                 }
             }
+
         } else if (this.state == RunnerState.Spawning || this.state == RunnerState.Running) {
             if ("spawn".equals(type) && spawnMessageIsValid(message)) {
                 this.state = RunnerState.Spawning;
                 this.onSpawnMessage(message);
-            } else if ("spawning_complete".equals(type) && spawnMessageIsValid(message)) {
-                this.state = RunnerState.Spawning;
-                this.onSpawnMessage(message);
                 this.state = RunnerState.Running;
+
+            } else if ("spawning_complete".equals(type) && spawnMessageIsValid(message)) {
+                this.state = RunnerState.Running;
+
             } else if ("stop".equals(type)) {
                 this.stop();
 
@@ -373,6 +375,7 @@ public class Runner {
                     logger.error("Error while switching from the state stopped to ready", ex);
                 }
             }
+
         } else if (this.state == RunnerState.Stopped) {
             if ("spawn".equals(type) && spawnMessageIsValid(message)) {
                 this.state = RunnerState.Spawning;
@@ -382,10 +385,8 @@ public class Runner {
                 if (rateLimiter != null && rateLimiter.isStopped()) {
                     rateLimiter.start();
                 }
-            } else if ("spawning_complete".equals(type) && spawnMessageIsValid(message)) {
-                this.state = RunnerState.Spawning;
-                this.onSpawnMessage(message);
 
+            } else if ("spawning_complete".equals(type) && spawnMessageIsValid(message)) {
                 AbstractRateLimiter rateLimiter = Locust.getInstance().getRateLimiter();
                 if (rateLimiter != null && rateLimiter.isStopped()) {
                     rateLimiter.start();
@@ -401,9 +402,12 @@ public class Runner {
                 new LinkedBlockingQueue<Runnable>(), new ThreadFactory() {
             @Override
             public Thread newThread(Runnable r) {
-                return new Thread(r);
+                Thread thread = new Thread(r);
+                thread.setName("locust4j-runner");
+                return thread;
             }
         });
+
         this.state = RunnerState.Ready;
         try {
             this.rpcClient.send(new Message("client_ready", null, -1, this.nodeID));
@@ -436,7 +440,7 @@ public class Runner {
         @Override
         public void run() {
             String name = Thread.currentThread().getName();
-            Thread.currentThread().setName(name + "receive-from-client");
+            Thread.currentThread().setName(name + "-receive-from-client");
             while (true) {
                 try {
                     Message message = runner.rpcClient.recv();
@@ -461,7 +465,7 @@ public class Runner {
         @Override
         public void run() {
             String name = Thread.currentThread().getName();
-            Thread.currentThread().setName(name + "send-to-client");
+            Thread.currentThread().setName(name + "-send-to-client");
             while (true) {
                 try {
                     Map<String, Object> data = runner.stats.getMessageToRunnerQueue().take();
@@ -498,7 +502,7 @@ public class Runner {
         @Override
         public void run() {
             String name = Thread.currentThread().getName();
-            Thread.currentThread().setName(name + "heartbeat");
+            Thread.currentThread().setName(name + "-heartbeat");
             while (true) {
                 try {
                     Thread.sleep(HEARTBEAT_INTERVAL);
@@ -508,6 +512,7 @@ public class Runner {
                     Map<String, Object> data = new HashMap<>(2);
                     data.put("state", runner.state.name().toLowerCase());
                     data.put("current_cpu_usage", getCpuUsage());
+                    data.put("current_memory_usage", getMemoryUsage());
                     boolean success = runner.stats.getMessageToRunnerQueue().offer(data);
                     if (!success) {
                         logger.error("Failed to insert heartbeat message to the queue");
@@ -521,7 +526,13 @@ public class Runner {
         }
 
         private double getCpuUsage() {
-            return osBean.getSystemCpuLoad() * 100;
+            // make percentage value with not more than 4 digits after decimal dot:
+            return ((double) Math.round(osBean.getSystemCpuLoad() * 1_000_000)) / 10_000;
+        }
+
+        private long getMemoryUsage() {
+            Runtime runtime = Runtime.getRuntime();
+            return runtime.totalMemory() - runtime.freeMemory();
         }
 
         private OperatingSystemMXBean getOsBean() {
@@ -541,6 +552,8 @@ public class Runner {
 
         @Override
         public void run() {
+            String name = Thread.currentThread().getName();
+            Thread.currentThread().setName(name + "-heartbeat-checker");
             while (true) {
                 try {
                     Thread.sleep(1000);

--- a/src/test/java/com/github/myzhan/locust4j/runtime/TestRunner.java
+++ b/src/test/java/com/github/myzhan/locust4j/runtime/TestRunner.java
@@ -131,7 +131,7 @@ public class TestRunner {
 
         Message spawnComplete = client.getToServerQueue().take();
         assertEquals("spawning_complete", spawnComplete.getType());
-        assertEquals(1, spawnComplete.getData().get("count"));
+        assertEquals(1, spawnComplete.getData().get("user_count"));
         assertEquals(runner.nodeID, spawnComplete.getNodeID());
 
         // send stop message


### PR DESCRIPTION
This PR fixes:
- zeromq socket synchronization: the socket is not thread safe, but two threads (Runner#Sender and Runner#Receiver) may send messages concurrently; this bug led to silent zmq connection termination and then heartbeats timeout;
- 'spawning_complete' message is not "valid 'spawn' message";
- locust master expects 'user_count' instead of 'count' in 'spawning_complete';
- add current memory usage stats to heartbeats;
- a bit of cosmetics on threads names.